### PR TITLE
include numbers in label matching

### DIFF
--- a/status.go
+++ b/status.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	exprTempStr = "coretemp_core[0-9]+_input"
-	exprHostStr = "Host(?::|\\(\\`)([a-z\\.-]+)"
+	exprHostStr = "Host(?::|\\(\\`)([0-9a-z\\.-]+)"
 	// host prefix & suffix. slightly stupid but needs to support:
 	// traefik v1 `traefik.frontend.rule`
 	// traefik v1 `traefik.<name>.frontend.rule`

--- a/status_test.go
+++ b/status_test.go
@@ -16,6 +16,7 @@ func TestHostFromLabel(t *testing.T) {
 		{"v1 comma", "Host:what.it.do,howdy.partner", "what.it.do"},
 		{"v1 comma", "Host:what.it.do,howdy.partner,what", "what.it.do"},
 		{"v2 normal", "Host(`what.it.do`)", "what.it.do"},
+		{"v2 number", "Host(`mp3.mixtape.fam`)", "mp3.mixtape.fam"},
 		{"v2 operator", "Path(`/path`) || Host(`what.it.do`)", "what.it.do"},
 		{"v2 with hyphen", "Path(`/path`) || Host(`what-dev.it.do`)", "what-dev.it.do"},
 		{"empty", "", ""},


### PR DESCRIPTION
host names with numbers included weren't being interpreted properly

```
go test                                                                                                     
--- FAIL: TestHostFromLabel (0.00s)
    --- FAIL: TestHostFromLabel/v2_number (0.00s)
        status_test.go:28: expected "mp3.mixtape.sc", got "mp"
FAIL
exit status 1
FAIL    go.senan.xyz/compose-status     0.010s
     ..:(╯°□°)╯彡┻━━┻
```